### PR TITLE
Fix duplicate speech when switching words

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
   <div id="root"></div>
 
   <script type="text/babel">
-    const {useState, useEffect} = React;
+    const {useState, useEffect, useRef} = React;
 
     const SpellingApp = () => {
       const [currentWord, setCurrentWord] = useState('');
@@ -26,6 +26,7 @@
       const [showAnswer, setShowAnswer] = useState(false);
       const [gameStarted, setGameStarted] = useState(false);
       const [letterCounts, setLetterCounts] = useState({});
+      const speakTimeoutRef = useRef(null);
 
       // Simple word list appropriate for kids
       const wordList = [
@@ -309,8 +310,22 @@
 
       useEffect(() => {
         if (gameStarted && currentWord) {
-          setTimeout(() => speakWord(), 500);
+          if (speakTimeoutRef.current) {
+            clearTimeout(speakTimeoutRef.current);
+          }
+
+          speakTimeoutRef.current = setTimeout(() => {
+            speakWord();
+            speakTimeoutRef.current = null;
+          }, 500);
         }
+
+        return () => {
+          if (speakTimeoutRef.current) {
+            clearTimeout(speakTimeoutRef.current);
+            speakTimeoutRef.current = null;
+          }
+        };
       }, [currentWord, gameStarted]);
 
       // Initialize voice loading on component mount


### PR DESCRIPTION
## Summary
- use `useRef` to track the timeout for speaking
- clear pending speak timeout when starting a new word

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684bbd8fc5b4832bb4ce95b43dfaef12