### PR TITLE
Update hint display

### DIFF
--- a/index.html
+++ b/index.html
@@ -476,17 +476,11 @@
                     </div>
                   )}
 
-                  {showDescription && !showAnswer && (
-                    <div className="bg-yellow-100 rounded-2xl p-3 mb-3">
-                      <p className="text-md text-gray-700">Hint: {getDescription(currentWord)}</p>
-                    </div>
-                  )}
-
                   {/* Input Display */}
                   <div className="mb-4">
                     <div className="bg-gray-100 rounded-2xl p-4 min-h-[60px] flex items-center justify-center">
                       <span className="text-2xl md:text-3xl font-bold text-gray-800 tracking-wider">
-                        {userInput || "Tap letters below..."}
+                        {userInput || (showDescription && !showAnswer ? `Hint: ${getDescription(currentWord)}` : "Tap letters below...")}
                       </span>
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
- stop inserting an extra block for the word description
- show the hint in the input placeholder area instead

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684bc38eea0c832b91169c4bbbc5cba0