### PR TITLE
Fix React rendering API

### DIFF
--- a/index.html
+++ b/index.html
@@ -617,8 +617,10 @@
       );
     };
 
-    // Render the app
-    ReactDOM.render(<SpellingApp />, document.getElementById('root'));
+    // Render the app using React 18's createRoot API
+    const rootElement = document.getElementById('root');
+    const root = ReactDOM.createRoot(rootElement);
+    root.render(<SpellingApp />);
   </script>
 </body>
 


### PR DESCRIPTION
## Summary
- use ReactDOM.createRoot to render the app for React 18

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684bc4762ed0832bb747b2ba59d22250